### PR TITLE
Update typescript README with fork disclaimer and poupe package references

### DIFF
--- a/java/dynamiccolor/ColorSpec2025.java
+++ b/java/dynamiccolor/ColorSpec2025.java
@@ -1210,10 +1210,21 @@ final class ColorSpec2025 extends ColorSpec2021 {
             .setPalette((s) -> s.primaryPalette)
             .setTone(
                 (s) -> {
-                  DynamicScheme tempS = DynamicScheme.from(s, /* isDark= */ false);
+                  DynamicScheme tempS =
+                      DynamicScheme.from(s, /* isDark= */ false, /* contrastLevel= */ 0.0);
                   return primaryContainer().getTone(tempS);
                 })
             .setIsBackground(true)
+            .setBackground(
+                (s) -> {
+                  if (s.platform == PHONE) {
+                    return s.isDark ? surfaceBright() : surfaceDim();
+                  } else {
+                    return null;
+                  }
+                })
+            .setContrastCurve(
+                (s) -> s.platform == PHONE && s.contrastLevel > 0 ? getContrastCurve(1.5) : null)
             .build();
     return super.primaryFixed().toBuilder()
         .extendSpecVersion(SpecVersion.SPEC_2025, color2025)
@@ -1280,10 +1291,21 @@ final class ColorSpec2025 extends ColorSpec2021 {
             .setPalette((s) -> s.secondaryPalette)
             .setTone(
                 (s) -> {
-                  DynamicScheme tempS = DynamicScheme.from(s, /* isDark= */ false);
+                  DynamicScheme tempS =
+                      DynamicScheme.from(s, /* isDark= */ false, /* contrastLevel= */ 0.0);
                   return secondaryContainer().getTone(tempS);
                 })
             .setIsBackground(true)
+            .setBackground(
+                (s) -> {
+                  if (s.platform == PHONE) {
+                    return s.isDark ? surfaceBright() : surfaceDim();
+                  } else {
+                    return null;
+                  }
+                })
+            .setContrastCurve(
+                (s) -> s.platform == PHONE && s.contrastLevel > 0 ? getContrastCurve(1.5) : null)
             .build();
     return super.secondaryFixed().toBuilder()
         .extendSpecVersion(SpecVersion.SPEC_2025, color2025)
@@ -1350,10 +1372,21 @@ final class ColorSpec2025 extends ColorSpec2021 {
             .setPalette((s) -> s.tertiaryPalette)
             .setTone(
                 (s) -> {
-                  DynamicScheme tempS = DynamicScheme.from(s, /* isDark= */ false);
+                  DynamicScheme tempS =
+                      DynamicScheme.from(s, /* isDark= */ false, /* contrastLevel= */ 0.0);
                   return tertiaryContainer().getTone(tempS);
                 })
             .setIsBackground(true)
+            .setBackground(
+                (s) -> {
+                  if (s.platform == PHONE) {
+                    return s.isDark ? surfaceBright() : surfaceDim();
+                  } else {
+                    return null;
+                  }
+                })
+            .setContrastCurve(
+                (s) -> s.platform == PHONE && s.contrastLevel > 0 ? getContrastCurve(1.5) : null)
             .build();
     return super.tertiaryFixed().toBuilder()
         .extendSpecVersion(SpecVersion.SPEC_2025, color2025)

--- a/java/dynamiccolor/DynamicScheme.java
+++ b/java/dynamiccolor/DynamicScheme.java
@@ -152,11 +152,15 @@ public class DynamicScheme {
   }
 
   public static DynamicScheme from(DynamicScheme other, boolean isDark) {
+    return from(other, isDark, other.contrastLevel);
+  }
+
+  public static DynamicScheme from(DynamicScheme other, boolean isDark, double contrastLevel) {
     return new DynamicScheme(
         other.sourceColorHct,
         other.variant,
         isDark,
-        other.contrastLevel,
+        contrastLevel,
         other.platform,
         other.specVersion,
         other.primaryPalette,

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,6 +1,11 @@
 # material-color-utilities
 
-[![npm package](https://badgen.net/npm/v/@material/material-color-utilities)](https://npmjs.com/package/@material/material-color-utilities)
+> [!IMPORTANT]
+> **This is a fork** of the original Material Color Utilities repository.
+> It is only intended for making releases of the TypeScript package and
+> will be kept in sync with the upstream repository.
+
+[![npm package](https://badgen.net/npm/v/@poupe/material-color-utilities)](https://npmjs.com/package/@poupe/material-color-utilities)
 
 Algorithms and utilities that power the Material Design 3 (M3) color system,
 including choosing theme colors from images and creating tones of colors; all in
@@ -12,10 +17,10 @@ for more information.
 
 ## Getting started
 
-`npm i @material/material-color-utilities` or `yarn add @material/material-color-utilities`
+`npm i @poupe/material-color-utilities` or `yarn add @poupe/material-color-utilities`
 
 ```typescript
-import { Hct } from "@material/material-color-utilities";
+import { Hct } from "@poupe/material-color-utilities";
 
 // Simple demonstration of HCT.
 const color = Hct.fromInt(0xff4285f4);
@@ -28,7 +33,7 @@ console.log(`Tone: ${color.tone}`);
 ### Theming
 
 ```typescript
-import { argbFromHex, themeFromSourceColor, applyTheme } from "@material/material-color-utilities";
+import { argbFromHex, themeFromSourceColor, applyTheme } from "@poupe/material-color-utilities";
 
 // Get the theme from a hex color
 const theme = themeFromSourceColor(argbFromHex('#f82506'), [

--- a/typescript/dynamiccolor/color_spec_2025.ts
+++ b/typescript/dynamiccolor/color_spec_2025.ts
@@ -651,10 +651,15 @@ export class ColorSpecDelegateImpl2025 extends ColorSpecDelegateImpl2021 {
       name: 'primary_fixed',
       palette: (s) => s.primaryPalette,
       tone: (s) => {
-        let tempS = Object.assign({}, s, {isDark: false});
+        let tempS = Object.assign({}, s, {isDark: false, contrastLevel: 0});
         return this.primaryContainer().getTone(tempS);
       },
       isBackground: true,
+      background: (s) =>
+          s.platform === 'phone' ? this.highestSurface(s) : undefined,
+      contrastCurve: (s) => s.platform === 'phone' && s.contrastLevel > 0 ?
+          getCurve(1.5) :
+          undefined,
     });
     return extendSpecVersion(super.primaryFixed(), '2025', color2025);
   }
@@ -815,10 +820,15 @@ export class ColorSpecDelegateImpl2025 extends ColorSpecDelegateImpl2021 {
       name: 'secondary_fixed',
       palette: (s) => s.secondaryPalette,
       tone: (s) => {
-        let tempS = Object.assign({}, s, {isDark: false});
+        let tempS = Object.assign({}, s, {isDark: false, contrastLevel: 0});
         return this.secondaryContainer().getTone(tempS);
       },
       isBackground: true,
+      background: (s) =>
+          s.platform === 'phone' ? this.highestSurface(s) : undefined,
+      contrastCurve: (s) => s.platform === 'phone' && s.contrastLevel > 0 ?
+          getCurve(1.5) :
+          undefined,
     });
     return extendSpecVersion(super.secondaryFixed(), '2025', color2025);
   }
@@ -979,10 +989,15 @@ export class ColorSpecDelegateImpl2025 extends ColorSpecDelegateImpl2021 {
       name: 'tertiary_fixed',
       palette: (s) => s.tertiaryPalette,
       tone: (s) => {
-        let tempS = Object.assign({}, s, {isDark: false});
+        let tempS = Object.assign({}, s, {isDark: false, contrastLevel: 0});
         return this.tertiaryContainer().getTone(tempS);
       },
       isBackground: true,
+      background: (s) =>
+          s.platform === 'phone' ? this.highestSurface(s) : undefined,
+      contrastCurve: (s) => s.platform === 'phone' && s.contrastLevel > 0 ?
+          getCurve(1.5) :
+          undefined,
     });
     return extendSpecVersion(super.tertiaryFixed(), '2025', color2025);
   }


### PR DESCRIPTION
## Summary
- Merge latest upstream changes from material-foundation/material-color-utilities
- Add fork disclaimer matching top-level README to typescript/README.md
- Update all package references from @material/material-color-utilities to @poupe/material-color-utilities
- Ensure consistency across documentation

## Upstream changes merged
- Fixed fixed colors in dark mode in medium and high contrast modes for 2025 colors (commit a14c591)

## Our changes
- Added important notice about this being a fork to typescript/README.md
- Updated npm badge URL to point to @poupe package
- Updated installation commands (npm/yarn)
- Updated all import statements in code examples

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all package references are updated
- [ ] Check that code examples are accurate
- [ ] Verify upstream changes are properly integrated